### PR TITLE
fix: typo error

### DIFF
--- a/iec62056_21/transports.py
+++ b/iec62056_21/transports.py
@@ -307,7 +307,7 @@ class SerialTransport(BaseTransport):
         return (
             f"{self.__class__.__name__}("
             f"port={self.port_name!r}, "
-            f"timeout={self.timeout!r}"
+            f"timeout={self.timeout!r})"
         )
 
 


### PR DESCRIPTION
minor typo error in `__repr__` method from `SerialTransport` class.