### PR TITLE
transports: Use the overridden timeout instead of self.timeout

### DIFF
--- a/iec62056_21/client.py
+++ b/iec62056_21/client.py
@@ -305,7 +305,7 @@ class Iec6205621Client:
 
         :param timeout:
         """
-        data = self.transport.read()
+        data = self.transport.read(timeout)
         if data.startswith(b"\x01"):
             # We probably received a password challenge
             return messages.CommandMessage.from_bytes(data)

--- a/iec62056_21/client.py
+++ b/iec62056_21/client.py
@@ -155,7 +155,7 @@ class Iec6205621Client:
 
         ident_msg = self.read_identification()
 
-        # Setting the baudrate to the one propsed by the device.
+        # Setting the baudrate to the one proposed by the device.
         self._switchover_baudrate_char = ident_msg.switchover_baudrate_char
         self.identification = ident_msg.identification
         self.manufacturer_id = ident_msg.manufacturer
@@ -271,7 +271,7 @@ class Iec6205621Client:
         Normal:
             Null chars should be sent to the device for 2.1-2.3 seconds with a maximum
             of 0,5 seconds between them.
-            After the last charachter the client shall wait 1.5-1,7 seconds until it
+            After the last character the client shall wait 1.5-1,7 seconds until it
             sends the request message
 
         :param fast:

--- a/iec62056_21/lis200.py
+++ b/iec62056_21/lis200.py
@@ -27,11 +27,11 @@ def parse_datetime(datetime_string, utc_offset=None):
 
 class ArchiveReadoutCommand(Iec6205621Data):
     """
-    A spacial readout commnad is needed to read archives.
+    A spacial readout command is needed to read archives.
 
-    Each data row contains the measurements save at a certain point in time.
+    Each data row contains the measurements saved at a certain point in time.
     Any range of the data in the archive can be read out. How to read the archive is
-    specified withing the data in the readout command. within the parenthesises.
+    specified within the data in the readout command within the parentheses.
 
     For attributes !=0 there is only one data row in the answer.
 
@@ -52,10 +52,10 @@ class ArchiveReadoutCommand(Iec6205621Data):
         Example if timestamp is the third value in the archive you need to set the
         position to 3 to specify a time range. Defaults to `1`. Max value is 99.
     :param str start: Lower limit (oldest data row) of the archive field to be read out.
-        Allowed lenght is 17 so it can contain timestamps. Defaults to `''` and if not
+        Allowed length is 17 so it can contain timestamps. Defaults to `''` and if not
         present the oldest available row is used as lower limit
     :param str end: Upper limit (newest data row) of the archive field to be read out.
-        Allowed lenght is 17 so it can contain timestamps. Defaults to `''` and if not
+        Allowed length is 17 so it can contain timestamps. Defaults to `''` and if not
         present the newest available data row is used as the upper limit.
     :param bool partial_blocks: Indicates if readout should be done via partial blocks.
         Defaults to `False`.
@@ -150,8 +150,8 @@ class ArchiveReadout:
 
         for line in self.values.data_block.data_lines:
 
-            # other positions are refered without initial 0. But that wont work when
-            # referenceing a list.
+            # other positions are referred without initial 0. But that wont work when
+            # referencing a list.
             datetime_index = self.datetime_position - 1
 
             timestamp = parse_datetime(

--- a/iec62056_21/transports.py
+++ b/iec62056_21/transports.py
@@ -56,7 +56,7 @@ class BaseTransport:
                 b = self.recv(1)
 
                 duration = time.time() - start_time
-                if duration > self.timeout:
+                if duration > timeout:
                     raise TimeoutError(f"Read in {self.__class__.__name__} timed out")
                 if not start_char_received:
                     # is start char?

--- a/iec62056_21/transports.py
+++ b/iec62056_21/transports.py
@@ -86,7 +86,7 @@ class BaseTransport:
             )
 
             if start_char == b"\x01":
-                # This is a command message, probably Password challange.
+                # This is a command message, probably Password challenge.
                 total_data += in_data
                 break
 
@@ -371,7 +371,7 @@ class TcpTransport(BaseTransport):
 
     def switch_baudrate(self, baud: int) -> None:
         """
-        Baudrate has not meaning in TCP/IP so we just dont do anything.
+        Baudrate has not meaning in TCP/IP so we just don't do anything.
 
         :param baud:
         """


### PR DESCRIPTION
I have not actually experienced any issues with this bit of code since nothing sets a timeout when calling `.read()` currently, but it's arguably more correct.  Also drive-by fixing some typos across the codebase.